### PR TITLE
Fix utils line wrapping bug and clean gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-echo "# Ignore environment variables
+# Ignore environment variables
 **/.env
 **/.env.local
 **/.env.*.local
@@ -14,7 +14,7 @@ __pycache__/
 # Virtual environment
 **/venv/
 **/env/
-**/.venv/   
+**/.venv/
 
 # Logs and database files
 **/*.log
@@ -49,7 +49,7 @@ coverage.xml
 .nyc_output/
 
 # Miscellaneous
-*.bak" > .gitignore
+*.bak
 .DS_Store
 
 # ignore pycache

--- a/financial-analysis/utils.py
+++ b/financial-analysis/utils.py
@@ -29,14 +29,15 @@ def pretty_print_result(result):
             words = line.split(' ')
             new_line = ''
             for word in words:
+                if new_line == '':
+                    # start the line with the first word
+                    new_line = word
+                    continue
                 if len(new_line) + len(word) + 1 > 80:
                     parsed_result.append(new_line)
                     new_line = word
                 else:
-                    if new_line == '':
-                        new_line = word
-                    else:
-                        new_line += ' ' + word
+                    new_line += ' ' + word
             parsed_result.append(new_line)
         else:
             parsed_result.append(line)

--- a/jobhunting-crew/utils.py
+++ b/jobhunting-crew/utils.py
@@ -29,14 +29,15 @@ def pretty_print_result(result):
             words = line.split(' ')
             new_line = ''
             for word in words:
+                if new_line == '':
+                    # start the line with the first word
+                    new_line = word
+                    continue
                 if len(new_line) + len(word) + 1 > 80:
                     parsed_result.append(new_line)
                     new_line = word
                 else:
-                    if new_line == '':
-                        new_line = word
-                    else:
-                        new_line += ' ' + word
+                    new_line += ' ' + word
             parsed_result.append(new_line)
         else:
             parsed_result.append(line)


### PR DESCRIPTION
## Summary
- clean up the broken `.gitignore`
- fix `pretty_print_result` so it doesn't insert empty lines when wrapping text

## Testing
- `python -m py_compile financial-analysis/utils.py jobhunting-crew/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686b154e62588331b0b119566dab3a2c